### PR TITLE
Feat/python array of structure

### DIFF
--- a/tests/python/aos/test_basic_python.py
+++ b/tests/python/aos/test_basic_python.py
@@ -1,0 +1,202 @@
+import pytest
+import cnda
+
+# Python-side tests for AoS (Array-of-Structures) bindings.
+
+def test_vec2f_basic_operations_binding():
+    # Construction and initialization
+    arr = cnda.ContiguousND_Vec2f([3, 4])
+    assert arr.ndim() == 2
+    assert arr.size() == 12
+    assert arr.shape() == [3, 4]
+
+    # Element access and modification
+    arr = cnda.ContiguousND_Vec2f([2, 3])
+    arr[0, 0] = cnda.Vec2f(1.0, 2.0)
+    arr[0, 1] = cnda.Vec2f(3.0, 4.0)
+    arr[1, 2] = cnda.Vec2f(5.0, 6.0)
+
+    assert arr[0, 0].x == pytest.approx(1.0)
+    assert arr[0, 0].y == pytest.approx(2.0)
+    assert arr[0, 1].x == pytest.approx(3.0)
+    assert arr[0, 1].y == pytest.approx(4.0)
+    assert arr[1, 2].x == pytest.approx(5.0)
+    assert arr[1, 2].y == pytest.approx(6.0)
+
+    # Field access via reference
+    arr = cnda.ContiguousND_Vec2f([2, 2])
+    arr[0, 0] = cnda.Vec2f(10.0, 20.0)
+    elem = arr[0, 0]
+    assert elem.x == pytest.approx(10.0)
+    assert elem.y == pytest.approx(20.0)
+    elem.x = 30.0
+    assert arr[0, 0].x == pytest.approx(30.0)
+
+    # Memory layout is contiguous
+    arr = cnda.ContiguousND_Vec2f([2, 3])
+    for i in range(2):
+        for j in range(3):
+            v = float(i * 10 + j)
+            arr[i, j] = cnda.Vec2f(v, v + 100.0)
+
+    # Verify flat data access
+    # Can read back in expected linear order, 
+    # indicating underlying storage is contiguous without unexpected rearrangement.
+    flat = arr.data()
+    assert flat[0].x == pytest.approx(0.0)
+    assert flat[0].y == pytest.approx(100.0)
+    assert flat[1].x == pytest.approx(1.0)
+    assert flat[5].x == pytest.approx(12.0)
+
+
+def test_vec3f_basic_operations_binding():
+    arr = cnda.ContiguousND_Vec3f([10, 10, 10])
+    assert arr.ndim() == 3
+    assert arr.size() == 1000
+
+    arr[1, 1, 1] = cnda.Vec3f(1.5, 2.5, 3.5)
+    assert arr[1, 1, 1].x == pytest.approx(1.5)
+    assert arr[1, 1, 1].y == pytest.approx(2.5)
+    assert arr[1, 1, 1].z == pytest.approx(3.5)
+
+
+def test_cell2d_fluid_example_binding():
+    grid = cnda.ContiguousND_Cell2D([5, 5])
+    assert grid.size() == 25
+    #Initialize boundaries and fluid cells
+    for i in range(5):
+        for j in range(5):
+            is_boundary = (i == 0 or i == 4 or j == 0 or j == 4)
+            u = 0.0 if is_boundary else 1.0
+            v = 0.0 if is_boundary else 0.5
+            flag = -1 if is_boundary else 1
+            grid[i, j] = cnda.Cell2D(u, v, flag)
+        
+    # Verify grid[i,j] = cnda.Cell2D(...) can be used to write the entire POD struct into the array correctly
+    # Verify grid[i, j].<field> can correctly read back the field values just written
+    assert grid[0, 0].flag == -1
+    assert grid[2, 2].u == pytest.approx(1.0)
+    assert grid[2, 2].v == pytest.approx(0.5)
+    assert grid[2, 2].flag == 1
+
+
+def test_cell3d_basic_binding():
+    grid = cnda.ContiguousND_Cell3D([10, 10, 10])
+    assert grid.size() == 1000
+
+    grid[1, 1, 1] = cnda.Cell3D(1.0, 2.0, 3.0, 1)
+    assert grid[1, 1, 1].u == pytest.approx(1.0)
+    assert grid[1, 1, 1].v == pytest.approx(2.0)
+    assert grid[1, 1, 1].w == pytest.approx(3.0)
+    assert grid[1, 1, 1].flag == 1
+
+
+def test_particle_system_binding():
+    particles = cnda.ContiguousND_Particle([5])
+    assert particles.size() == 5
+
+    dt = 0.1
+    for i in range(5):
+        particles[i] = cnda.Particle(0.0, 0.0, 0.0, float(i), 0.0, 0.0, 1.0)
+        particles[i].x += particles[i].vx * dt
+
+    assert particles[0].x == pytest.approx(0.0)
+    assert particles[1].x == pytest.approx(0.1)
+    assert particles[4].x == pytest.approx(0.4)
+    assert particles[1].vx == pytest.approx(1.0)
+    assert particles[0].mass == pytest.approx(1.0)
+
+
+def test_materialpoint_grid_binding():
+    grid = cnda.ContiguousND_MaterialPoint([3, 3])
+    assert grid.size() == 9
+
+    grid[0, 0] = cnda.MaterialPoint(1.0, 300.0, 101.3, 1)
+    grid[1, 1] = cnda.MaterialPoint(1000.0, 293.0, 101.3, 2)
+    grid[2, 2] = cnda.MaterialPoint(7850.0, 293.0, 101.3, 3)
+
+    assert grid[0, 0].density == pytest.approx(1.0)
+    assert grid[1, 1].density == pytest.approx(1000.0)
+    assert grid[2, 2].density == pytest.approx(7850.0)
+    assert grid[0, 0].id == 1
+    assert grid[1, 1].id == 2
+    assert grid[2, 2].id == 3
+
+
+def test_at_bounds_checking_binding():
+    # at() method with bounds checking
+    # Verify `at()` enforces bounds checking (raises on invalid indices) and
+    # Return correct field values for valid accesses.
+    arr = cnda.ContiguousND_Vec2f([2, 3])
+    arr[0, 0] = cnda.Vec2f(1.0, 2.0)
+    assert arr.at([0, 0]).x == pytest.approx(1.0)
+
+    grid = cnda.ContiguousND_Cell2D([5, 5])
+    grid[2, 3] = cnda.Cell2D(1.5, 2.5, 10)
+    assert grid.at([2, 3]).u == pytest.approx(1.5)
+    assert grid.at([2, 3]).v == pytest.approx(2.5)
+    assert grid.at([2, 3]).flag == 10
+
+    # out-of-range indices should raise an IndexError on the Python side
+    with pytest.raises(IndexError):
+        _ = arr.at([2, 0])
+    with pytest.raises(IndexError):
+        _ = arr.at([0, 3])
+    with pytest.raises(IndexError):
+        _ = arr.at([5, 5])
+
+
+def test_memory_size_validation_binding():
+
+    # Verify `sizeof` for AoS types match the expected scalar multiples using
+    #cnda.sizeof_aos` (C++ sizeof exposed) and Python ctypes.sizeof
+    import ctypes
+
+    # Basic scalar expectations
+    assert cnda.sizeof_aos("Vec2f") == 2 * ctypes.sizeof(ctypes.c_float)
+    assert cnda.sizeof_aos("Vec3f") == 3 * ctypes.sizeof(ctypes.c_float)
+    assert cnda.sizeof_aos("Particle") == 7 * ctypes.sizeof(ctypes.c_double)
+
+    # Compound types must be at least the sum of their components (allowing possible padding)
+    assert cnda.sizeof_aos("Cell2D") >= 2 * ctypes.sizeof(ctypes.c_float) + ctypes.sizeof(ctypes.c_int32)
+    assert cnda.sizeof_aos("Cell3D") >= 3 * ctypes.sizeof(ctypes.c_float) + ctypes.sizeof(ctypes.c_int32)
+    assert cnda.sizeof_aos("MaterialPoint") >= 3 * ctypes.sizeof(ctypes.c_float) + ctypes.sizeof(ctypes.c_int32)
+
+    # Verify contiguous-like mapping by writing via index and reading back from `data()`
+    arr = cnda.ContiguousND_Vec2f([100])
+    for i in range(100):
+        arr[i] = cnda.Vec2f(float(i), float(i + 100.0))
+
+    flat = arr.data()
+    assert flat[0].x == pytest.approx(0.0)
+    assert flat[99].x == pytest.approx(99.0)
+    # Ensure element retrieved from data() matches indexed access
+    assert flat[50].x == pytest.approx(arr[50].x)
+
+
+def test_pod_type_guarantees_binding():
+    # Use ctypes to memcpy between two arrays of the same POD layout
+    # Validate fields match after the raw copy 
+    # Mirror std::memcpy usage in the C++ test
+
+    import ctypes
+
+    class Vec2f_ct(ctypes.Structure):
+        _fields_ = [("x", ctypes.c_float), ("y", ctypes.c_float)]
+
+    # Create source and destination arrays (2x2)
+    src = (Vec2f_ct * 4)()
+    dst = (Vec2f_ct * 4)()
+
+    # Initialize src entries like the C++ test
+    src[0].x, src[0].y = 1.0, 2.0
+    src[3].x, src[3].y = 3.0, 4.0
+
+    # Raw memory copy
+    ctypes.memmove(ctypes.addressof(dst), ctypes.addressof(src), ctypes.sizeof(src))
+
+    # Validate fields survived the memcpy
+    assert dst[0].x == pytest.approx(1.0)
+    assert dst[0].y == pytest.approx(2.0)
+    assert dst[3].x == pytest.approx(3.0)
+    assert dst[3].y == pytest.approx(4.0)

--- a/tests/python/aos/test_field_layout_python.py
+++ b/tests/python/aos/test_field_layout_python.py
@@ -1,0 +1,235 @@
+import ctypes
+import pytest
+import cnda
+
+# ctypes mirrors for offsetof/sizeof validation
+class Vec2f_ct(ctypes.Structure):
+    _fields_ = [("x", ctypes.c_float), ("y", ctypes.c_float)]
+
+
+class Vec3f_ct(ctypes.Structure):
+    _fields_ = [("x", ctypes.c_float), ("y", ctypes.c_float), ("z", ctypes.c_float)]
+
+
+class Cell2D_ct(ctypes.Structure):
+    _fields_ = [("u", ctypes.c_float), ("v", ctypes.c_float), ("flag", ctypes.c_int32)]
+
+
+class Cell3D_ct(ctypes.Structure):
+    _fields_ = [("u", ctypes.c_float), ("v", ctypes.c_float), ("w", ctypes.c_float), ("flag", ctypes.c_int32)]
+
+
+class Particle_ct(ctypes.Structure):
+    _fields_ = [("x", ctypes.c_double), ("y", ctypes.c_double), ("z", ctypes.c_double),
+                ("vx", ctypes.c_double), ("vy", ctypes.c_double), ("vz", ctypes.c_double),
+                ("mass", ctypes.c_double)]
+
+
+class MaterialPoint_ct(ctypes.Structure):
+    _fields_ = [("density", ctypes.c_float), ("temperature", ctypes.c_float), ("pressure", ctypes.c_float), ("id", ctypes.c_int32)]
+
+
+def test_field_offset_validation_ctypes():
+    # Field memory offsets and per-field offsetof validation using ctypes
+
+    # Vec2f
+    assert getattr(Vec2f_ct, "x").offset == 0
+    assert getattr(Vec2f_ct, "y").offset == ctypes.sizeof(ctypes.c_float)
+    assert ctypes.sizeof(Vec2f_ct) == 2 * ctypes.sizeof(ctypes.c_float)
+
+    # Vec3f
+    assert getattr(Vec3f_ct, "x").offset == 0
+    assert getattr(Vec3f_ct, "y").offset == ctypes.sizeof(ctypes.c_float)
+    assert getattr(Vec3f_ct, "z").offset == 2 * ctypes.sizeof(ctypes.c_float)
+    assert ctypes.sizeof(Vec3f_ct) == 3 * ctypes.sizeof(ctypes.c_float)
+
+    # Cell2D
+    assert getattr(Cell2D_ct, "u").offset == 0
+    assert getattr(Cell2D_ct, "v").offset == ctypes.sizeof(ctypes.c_float)
+    assert getattr(Cell2D_ct, "flag").offset == 2 * ctypes.sizeof(ctypes.c_float)
+    assert ctypes.sizeof(Cell2D_ct) == 2 * ctypes.sizeof(ctypes.c_float) + ctypes.sizeof(ctypes.c_int32)
+
+    # Cell3D
+    assert getattr(Cell3D_ct, "u").offset == 0
+    assert getattr(Cell3D_ct, "v").offset == ctypes.sizeof(ctypes.c_float)
+    assert getattr(Cell3D_ct, "w").offset == 2 * ctypes.sizeof(ctypes.c_float)
+    assert getattr(Cell3D_ct, "flag").offset == 3 * ctypes.sizeof(ctypes.c_float)
+    assert ctypes.sizeof(Cell3D_ct) == 3 * ctypes.sizeof(ctypes.c_float) + ctypes.sizeof(ctypes.c_int32)
+
+    # Particle (doubles)
+    assert getattr(Particle_ct, "x").offset == 0
+    assert getattr(Particle_ct, "y").offset == ctypes.sizeof(ctypes.c_double)
+    assert getattr(Particle_ct, "z").offset == 2 * ctypes.sizeof(ctypes.c_double)
+    assert ctypes.sizeof(Particle_ct) == 7 * ctypes.sizeof(ctypes.c_double)
+
+    # MaterialPoint
+    assert getattr(MaterialPoint_ct, "density").offset == 0
+    assert getattr(MaterialPoint_ct, "temperature").offset == ctypes.sizeof(ctypes.c_float)
+    assert getattr(MaterialPoint_ct, "pressure").offset == 2 * ctypes.sizeof(ctypes.c_float)
+    assert getattr(MaterialPoint_ct, "id").offset == 3 * ctypes.sizeof(ctypes.c_float)
+    assert ctypes.sizeof(MaterialPoint_ct) == 3 * ctypes.sizeof(ctypes.c_float) + ctypes.sizeof(ctypes.c_int32)
+
+
+def test_field_access_api_consistency_binding():
+    # Field Access API Consistency: low-level checks using element_ptr and ctypes
+
+    assert hasattr(cnda.ContiguousND_Vec2f, 'element_ptr') or hasattr(cnda.ContiguousND_Vec2f, 'element_ptr')
+
+    # Vec2f: assign and verify via element_ptr -> float* arithmetic
+    arr = cnda.ContiguousND_Vec2f([1])
+    arr[0] = cnda.Vec2f(1.5, 2.5)
+    p = arr.element_ptr(0)
+    float_p = ctypes.cast(ctypes.c_void_p(p), ctypes.POINTER(ctypes.c_float))
+    assert float_p[0] == pytest.approx(1.5)
+    assert float_p[1] == pytest.approx(2.5)
+
+    x_addr = p + getattr(Vec2f_ct, 'x').offset
+    y_addr = p + getattr(Vec2f_ct, 'y').offset
+    assert (y_addr - x_addr) == ctypes.sizeof(ctypes.c_float)
+
+    # Vec3f: float pointer arithmetic
+    arr3 = cnda.ContiguousND_Vec3f([1])
+    arr3[0] = cnda.Vec3f(10.0, 20.0, 30.0)
+    p3 = arr3.element_ptr(0)
+    float_p3 = ctypes.cast(ctypes.c_void_p(p3), ctypes.POINTER(ctypes.c_float))
+    assert float_p3[0] == pytest.approx(10.0)
+    assert float_p3[1] == pytest.approx(20.0)
+    assert float_p3[2] == pytest.approx(30.0)
+    
+    assert arr3[0].x == pytest.approx(10.0)
+    assert arr3[0].y == pytest.approx(20.0)
+    assert arr3[0].z == pytest.approx(30.0)
+
+    # Cell2D: floats then int32 flag at offset
+    c2 = cnda.ContiguousND_Cell2D([1])
+    c2[0] = cnda.Cell2D(5.5, 6.5, 42)
+    pc2 = c2.element_ptr(0)
+    float_pc2 = ctypes.cast(ctypes.c_void_p(pc2), ctypes.POINTER(ctypes.c_float))
+    assert float_pc2[0] == pytest.approx(5.5)
+    assert float_pc2[1] == pytest.approx(6.5)
+    flag_addr = pc2 + getattr(Cell2D_ct, 'flag').offset
+    flag_val = ctypes.cast(ctypes.c_void_p(flag_addr), ctypes.POINTER(ctypes.c_int32)).contents.value
+    assert flag_val == 42
+
+    # Cell3D: floats then int32 flag
+    c3 = cnda.ContiguousND_Cell3D([1])
+    c3[0] = cnda.Cell3D(1.0, 2.0, 3.0, 99)
+    pc3 = c3.element_ptr(0)
+    float_pc3 = ctypes.cast(ctypes.c_void_p(pc3), ctypes.POINTER(ctypes.c_float))
+    assert float_pc3[0] == pytest.approx(1.0)
+    assert float_pc3[1] == pytest.approx(2.0)
+    assert float_pc3[2] == pytest.approx(3.0)
+    flag_addr3 = pc3 + getattr(Cell3D_ct, 'flag').offset
+    flag_val3 = ctypes.cast(ctypes.c_void_p(flag_addr3), ctypes.POINTER(ctypes.c_int32)).contents.value
+    assert flag_val3 == 99
+
+    # Particle: use double pointer arithmetic
+    p_arr = cnda.ContiguousND_Particle([1])
+    p_arr[0] = cnda.Particle(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0)
+    pp = p_arr.element_ptr(0)
+    double_pp = ctypes.cast(ctypes.c_void_p(pp), ctypes.POINTER(ctypes.c_double))
+    assert double_pp[0] == pytest.approx(1.0)
+    assert double_pp[1] == pytest.approx(2.0)
+    assert double_pp[2] == pytest.approx(3.0)
+    assert double_pp[3] == pytest.approx(4.0)
+    assert double_pp[4] == pytest.approx(5.0)
+    assert double_pp[5] == pytest.approx(6.0)
+    assert double_pp[6] == pytest.approx(7.0)
+
+    # MaterialPoint: floats and int32 id
+    m = cnda.ContiguousND_MaterialPoint([1])
+    m[0] = cnda.MaterialPoint(1.0, 300.0, 101.3, 1)
+    pm = m.element_ptr(0)
+    float_pm = ctypes.cast(ctypes.c_void_p(pm), ctypes.POINTER(ctypes.c_float))
+    assert float_pm[0] == pytest.approx(1.0)
+    assert float_pm[1] == pytest.approx(300.0)
+    assert float_pm[2] == pytest.approx(101.3)
+    id_addr = pm + getattr(MaterialPoint_ct, 'id').offset
+    id_val = ctypes.cast(ctypes.c_void_p(id_addr), ctypes.POINTER(ctypes.c_int32)).contents.value
+    assert id_val == 1
+
+
+def test_field_mixup_prevention_binding():
+    # Ensure fields are distinct and not mixed between elements or fields
+
+    # Vec2f distinct
+    a = cnda.ContiguousND_Vec2f([2])
+    a[0] = cnda.Vec2f(1.0, 2.0)
+    a[1] = cnda.Vec2f(10.0, 20.0)
+    assert a[0].x != a[0].y
+    assert a[1].x != a[1].y
+    # Values should be correct
+    assert a[0].x == pytest.approx(1.0)
+    assert a[0].y == pytest.approx(2.0)
+
+    # Vec3f distinct
+    b = cnda.ContiguousND_Vec3f([2])
+    b[0] = cnda.Vec3f(1.0, 2.0, 3.0)
+    b[1] = cnda.Vec3f(10.0, 20.0, 30.0)
+    assert b[0].x != b[0].y
+    assert b[0].y != b[0].z
+    # Values should be correct
+    assert b[0].x == pytest.approx(1.0)
+    assert b[0].y == pytest.approx(2.0)
+    assert b[0].z == pytest.approx(3.0)
+
+    # Cell2D distinct
+    c = cnda.ContiguousND_Cell2D([2])
+    c[0] = cnda.Cell2D(5.5, 6.5, 42)
+    assert c[0].u != c[0].v
+    assert c[0].flag == 42
+    # Values should be correct
+    assert c[0].u == pytest.approx(5.5)
+    assert c[0].v == pytest.approx(6.5)
+
+    # Particle position vs velocity
+    pa = cnda.ContiguousND_Particle([1])
+    pa[0] = cnda.Particle(1.0, 2.0, 3.0, 10.0, 20.0, 30.0, 100.0)
+    assert pa[0].x != pa[0].vx
+    assert pa[0].mass == pytest.approx(100.0)
+    # Values should be correct
+    assert pa[0].x == pytest.approx(1.0)
+    assert pa[0].vx == pytest.approx(10.0)
+    assert pa[0].mass == pytest.approx(100.0)
+
+
+def test_contiguous_layout_behavior_binding():
+    # check for contiguous layout/stride.
+    v = cnda.ContiguousND_Vec2f([3])
+    v[0] = cnda.Vec2f(1.0, 1.0)
+    v[1] = cnda.Vec2f(2.0, 2.0)
+    v[2] = cnda.Vec2f(3.0, 3.0)
+
+    p0 = v.element_ptr(0)
+    p1 = v.element_ptr(1)
+    p2 = v.element_ptr(2)
+
+    # element_ptr should return an integer address
+    assert isinstance(p0, int)
+
+    # Consecutive element pointers should be separated by sizeof(Vec2f)
+    assert (p1 - p0) == ctypes.sizeof(Vec2f_ct)
+    assert (p2 - p1) == ctypes.sizeof(Vec2f_ct)
+
+    # test for ContiguousND_Cell3D
+    inst3 = cnda.ContiguousND_Cell3D([5])
+    assert hasattr(inst3, 'element_ptr') and callable(getattr(inst3, 'element_ptr'))
+
+    # Check consecutive element addresses equal sizeof(Cell3D_ct)
+    for i in range(4):
+        p_i = inst3.element_ptr(i)
+        p_i1 = inst3.element_ptr(i + 1)
+        assert isinstance(p_i, int)
+        assert isinstance(p_i1, int)
+        assert (p_i1 - p_i) == ctypes.sizeof(Cell3D_ct)
+
+
+def test_sizeof_validation_all_aos():
+    # sizeof() validation for all AoS types using ctypes sizes.
+    
+    assert ctypes.sizeof(Vec2f_ct) == 2 * ctypes.sizeof(ctypes.c_float)
+    assert ctypes.sizeof(Vec3f_ct) == 3 * ctypes.sizeof(ctypes.c_float)
+    assert ctypes.sizeof(Cell2D_ct) == 2 * ctypes.sizeof(ctypes.c_float) + ctypes.sizeof(ctypes.c_int32)
+    assert ctypes.sizeof(Cell3D_ct) == 3 * ctypes.sizeof(ctypes.c_float) + ctypes.sizeof(ctypes.c_int32)
+    assert ctypes.sizeof(Particle_ct) == 7 * ctypes.sizeof(ctypes.c_double)
+    assert ctypes.sizeof(MaterialPoint_ct) == 3 * ctypes.sizeof(ctypes.c_float) + ctypes.sizeof(ctypes.c_int32)

--- a/tests/python/aos/test_indexing_python.py
+++ b/tests/python/aos/test_indexing_python.py
@@ -1,0 +1,110 @@
+import ctypes
+import pytest
+import cnda
+
+def test_vec2f_stride_and_indexing():
+    arr = cnda.ContiguousND_Vec2f([3, 4])
+    strides = arr.strides()
+
+    assert len(strides) == 2
+    assert strides[0] == 4
+    assert strides[1] == 1
+    assert arr.index([1, 2]) == 6
+
+    # Now verify actual addresses using pointer helpers exposed from C++
+    elem_size = ctypes.sizeof(ctypes.c_float) * 2  # Vec2f: 2 floats
+    base_addr = arr.data_ptr()
+    elem_addr = arr.element_ptr([1, 2])
+    assert elem_addr == base_addr + 6 * elem_size
+
+
+def test_cell3d_pointer_arithmetic():
+    arr = cnda.ContiguousND_Cell3D([2, 3])
+    strides = arr.strides()
+    assert strides[0] == 3
+    assert strides[1] == 1
+
+    arr[1, 2] = cnda.Cell3D(1.0, 2.0, 3.0, 4)
+    idx = arr.index([1, 2])
+    assert idx == 5
+
+    # byte offset using pointer helpers
+    elem_size = 3 * ctypes.sizeof(ctypes.c_float) + ctypes.sizeof(ctypes.c_int32)
+    base_addr = arr.data_ptr()
+    elem_addr = arr.element_ptr([1, 2])
+    assert elem_addr == base_addr + idx * elem_size
+
+    # field values are visible
+    cell = arr[1, 2]
+    assert cell.u == pytest.approx(1.0)
+    assert cell.v == pytest.approx(2.0)
+    assert cell.w == pytest.approx(3.0)
+    assert cell.flag == 4
+
+
+def test_particle_array_memory_continuity():
+    particles = cnda.ContiguousND_Particle([10])
+    assert particles.strides()[0] == 1
+
+    for i in range(10):
+        particles[i] = cnda.Particle(float(i), float(i * 2), float(i * 3), float(i * 4), float(i * 5), float(i * 6), 1.0)
+
+    elem_size = 7 * ctypes.sizeof(ctypes.c_double)  # 7 doubles
+    base_addr = particles.data_ptr()
+    for i in range(10):
+        idx = particles.index([i])
+        assert idx == i
+        elem_addr = particles.element_ptr([i])
+        assert elem_addr == base_addr + i * elem_size
+        assert particles[i].x == pytest.approx(float(i))
+        assert particles[i].y == pytest.approx(float(i * 2))
+
+
+def test_3d_array_element_spacing():
+    arr = cnda.ContiguousND_Vec3f([2, 3, 4])
+    strides = arr.strides()
+
+    assert strides[0] == 12
+    assert strides[1] == 4
+    assert strides[2] == 1
+
+    # test some element indices
+    assert arr.index([0, 0, 0]) == 0
+    assert arr.index([0, 0, 1]) == 1
+    assert arr.index([0, 1, 0]) == 4
+    assert arr.index([1, 0, 0]) == 12
+    assert arr.index([1, 2, 3]) == 23
+
+    elem_size = 3 * ctypes.sizeof(ctypes.c_float)
+    base_addr = arr.data_ptr()
+    elem_addr = arr.element_ptr([1, 2, 3])
+    assert elem_addr == base_addr + 23 * elem_size
+    assert arr.index([1, 2, 3]) == 23
+
+
+def test_aos_vs_scalar_sizeof_comparison():
+    # To verify that AoS and scalar arrays of same shape have different total byte sizes
+    scalar_arr = cnda.ContiguousND_float([3, 4])
+    aos_arr = cnda.ContiguousND_Vec2f([3, 4])
+
+    assert scalar_arr.strides() == aos_arr.strides()
+    assert scalar_arr.size() == aos_arr.size()
+
+    # scalar size * sizeof(float) == 48
+    assert scalar_arr.size() * ctypes.sizeof(ctypes.c_float) == 48
+    # aos array total bytes
+    aos_elem_size = 2 * ctypes.sizeof(ctypes.c_float)
+    assert aos_arr.size() * aos_elem_size == 96
+
+
+def test_pointer_arithmetic_scales_by_sizeof_T():
+    arr = cnda.ContiguousND_Cell3D([5, 5])
+
+    # verify element index distances correspond to expected element counts
+    # Get actual addresses and verify byte differences scale by sizeof(T)
+    p0_addr = arr.element_ptr([0, 0])
+    p1_addr = arr.element_ptr([0, 1])
+    p2_addr = arr.element_ptr([1, 0])
+    # int_32 is for the flag field
+    assert p1_addr - p0_addr == ctypes.sizeof(ctypes.c_float) * 3 + ctypes.sizeof(ctypes.c_int32)
+    assert p2_addr - p0_addr == 5 * (ctypes.sizeof(ctypes.c_float) * 3 + ctypes.sizeof(ctypes.c_int32))


### PR DESCRIPTION
Red-Add failing AoS tests in python
- Add failing tests in test_basic_python.py for AoS type construction, access, POD compliance, and bounds checking.
- Add failing tests in test_field_layout_python.py to verify field offsets, memory layout, and API consistency.
- Add failing tests in test_indexing_python.py to verify indexing, stride, index-to-offset mapping across dims and types.

Green
- Implemented AoS-compatible struct types (`Vec2f`, `Vec3f`, `Cell2D`, `Cell3D`, `Particle`, `MaterialPoint`) in binding.cpp for python.
- Pass all the test cases in python

Fix #35 
